### PR TITLE
Add Duration#to_rounded_s method

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This works for MRI; it may or may not work for other Rubies.
+RUBY_VERSION=`ruby --version | cut -d ' ' -f 2 | sed 's/p.*//'`
+
+##
+## Initialise Gemset and setup if `rbenv` is available
+##
+
+rm -f Gemfile.lock .rbenv-gemsets
+
+if [[ `rbenv --version 2>/dev/null` ]]; then
+  rbenv gemset delete $RUBY_VERSION ./tmp/gemset 2>/dev/null || true
+  find ./tmp/gemset -delete 2>/dev/null || true
+  rbenv rehash
+  rbenv gemset create $RUBY_VERSION ./tmp/gemset
+  echo ./tmp/gemset > .rbenv-gemsets
+  rbenv rehash
+fi
+
+##
+## Install Gems
+##
+
+gem install yard
+yard config --gem-install-yri
+
+gem install bundler rspec rake:10.5.0 # obsolete since March 2016
+bundle install --binstubs --local

--- a/lib/timerizer/duration/rounded_time.rb
+++ b/lib/timerizer/duration/rounded_time.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+module Timerizer
+  class Duration
+    # Wraps rounding a {Timerizer::Duration} to the nearest value by the number
+    # of "places", which are customary time units (seconds, minutes, hours,
+    # days, months, years, etc; decades and weeks are not included).
+    #
+    # @private
+    class RoundedTime
+      extend Forwardable
+
+      # @!method remainder_times
+      #   @return (see TermTimes#remainder_times)
+      # @!method target_unit
+      #   @return (see TermTimes#target_unit)
+      # @!method times
+      #   @return (see TermTimes#times)
+      def_delegators :@tt, :remainder_times, :target_unit, :times
+
+      # Default "places" (units, e.g., hours/minutes) to use for rounding.
+      DEFAULT_PLACES = 2
+      # Default {Timerizer::Duration::UNITS} *not* to include in rounded value.
+      OMITTED_KEYS = [:decades, :weeks]
+
+      # Given an original {Timerizer::Duration} instance, return a new instance
+      # that "rounds" the duration to the closest value expressed in a certain
+      # number of units (default 2).
+      #
+      # @param [{Timerizer::Duration}] duration Object encapsulating a duration
+      #                     (in hours, minutes, etc) to "round" to a number of
+      #                     units specified by `places`.
+      # @param [Integer] places Number of units to include in rounded value.
+      #                     Default is 2.
+      # @param [Array<Symbol>] omitted_keys Units to omit from calculation or
+      #                     return value. Default is `[:decades, :weeks]`
+      # @return {Timerizer::Duration}
+      # @example
+      #   t = (12.hours 16.minutes 47.seconds).ago
+      #   d = Time.since(t)
+      #   d2 = RoundedTime.call(d)
+      #   d.to_s  # => "12 hours, 16 minutes, 47 seconds"
+      #   d2.to_s # => "12 hours, 17 minutes"
+      #
+      def self.call(duration, places = DEFAULT_PLACES,
+                    omitted_keys = OMITTED_KEYS)
+        new(duration, places, omitted_keys).call
+      end
+
+      # High-level method to do calculations on component durations.
+      #
+      # @return {Timerizer::Duration}
+      #
+      def call
+        remainder = sum_of(remainder_times)
+        sum_of(times) + offset_from(remainder)
+      end
+
+      private
+
+      # Initial value for adding a collection of Duration instances.
+      # (see #sum_of)
+      ZERO_TIME = Timerizer::Duration.new(seconds: 0)
+      private_constant :ZERO_TIME
+
+      # Private initialiser to prevent direct instantiation by client code.
+      #
+      # @param [{Timerizer::Duration}] duration Object encapsulating a duration
+      #                     (in hours, minutes, etc) to "round" to a number of
+      #                     units specified by `places`.
+      # @param [Integer] places Number of units to include in rounded value.
+      #                     Default is 2.
+      # @param [Array<Symbol>] omitted_keys Units to omit from calculation or
+      #                     return value. Default is `[:decades, :weeks]`
+      #
+      def initialize(duration, places = DEFAULT_PLACES,
+                     omitted_keys = OMITTED_KEYS)
+        @tt = TermTimes.new(duration, omitted_keys).call(places).freeze
+      end
+
+      # Determine whether returned {Timerizer::Duration} value should be rounded
+      # up or down based on a remainder value.
+      #
+      # If the remainder value is more than half of the {#target_unit}, then
+      # this will return a duration of 1 times the target unit, else a duration
+      # of {ZERO_TIME}.
+      #
+      # @return [{Timerizer::Duration}] Either zero or 1 times the `target_unit`
+      # @param [{Timerizer::Duration}] remainder Value of input duration less
+      #                     than one `target_unit`
+      def offset_from(remainder)
+        Timerizer::Duration.new((remainder * 2).to_units(target_unit))
+      end
+
+      # Add all time (Duration) values in an Array (or other Enumerable).
+      #
+      # @return [{Timerizer::Duration}] Sum total of input values.
+      # @param [Array<{Timerizer::Duration}>] Unit values to add together
+      #
+      def sum_of(time_values)
+        time_values.inject(ZERO_TIME, :+)
+      end
+
+      # Convert a single {Timerizer::Duration} instance into an enumeration of
+      # per-unit Duration instances (hours, minutes, etc).
+      #
+      # @private
+      class TermTimes
+        # Least-significant time unit (e.g., ``:days`) used for rounding.
+        # @return [Symbol] Least-significant time unit in the resulting value.
+        attr_reader :target_unit
+        # Time units to be included in "rounded" result, before rounding.
+        # @return [Array<{Timerizer::Duration}>] Base result time-unit values.
+        attr_reader :times
+        # Time units to be "rounded" to adjust resulting Duration value.
+        # @return [Array<{Timerizer::Duration}>] Remaining time-unit values.
+        attr_reader :remainder_times
+
+        # Build array of time-part values based on input {Timerizer::Duration}.
+        #
+        # @param [{Timerizer::Duration}] duration Time differential used as
+        #                     input.
+        # @param [Array<Symbol>] omitted_keys {Timerizer::Duration::UNITS}
+        #                     values to exclude from resulting value.
+        #
+        def initialize(duration, omitted_keys)
+          @part_values = filter_units(duration, omitted_keys)
+        end
+
+        # Compute per-unit {Timerizer::Duration} values, split based on unit
+        # count
+        #
+        # @param [Integer] places Number of time units to include in main Array.
+        def call(places)
+          # Note that `places` may exceed the number of actual units in the
+          # value. For example, with a duration of `(10.days)` and a `places`
+          # value of 2. Adjust as needed.
+          places = @part_values.count - 1 if @part_values.count < places
+          # If a zero-time `duration` is passed in, then @part_values will be
+          # empty, and the key arithmetic will return `nil`. Adjust as needed.
+          @target_unit = @part_values.keys[places - 1] || :seconds
+          term_times = unit_times
+          @times = term_times[0..places - 1]
+          @remainder_times = term_times[@times.count..-1]
+          self
+        end
+
+        private
+
+        def filter_units(duration, omitted_keys)
+          unit_keys = Timerizer::Duration::UNITS.keys - omitted_keys
+          duration.to_units(*unit_keys).reject { |_, v| v.zero? }
+        end
+
+        def unit_times
+          @part_values.map { |unit, val| Timerizer::Duration.new(unit => val) }
+        end
+      end # class RoundedTime::TermTimes
+      private_constant :TermTimes
+    end # class RoundedTime
+  end
+end

--- a/spec/timerizer/duration/to_rounded_s_spec.rb
+++ b/spec/timerizer/duration/to_rounded_s_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require 'timerizer/duration'
+
+RSpec.describe Timerizer::Duration do
+  describe '#to_rounded_s' do
+    describe 'passes all (adjusted) #to_s specs including' do
+      it "converts all units into a string" do
+        expect(
+          (1.year 3.months).to_rounded_s(:long)
+        ).to eq('1 year, 3 months')
+
+        expect(
+          (4.days 1.hour).to_rounded_s(:long)
+        ).to eq('4 days, 1 hour')
+
+        expect(
+          (3.minutes 4.seconds).to_rounded_s
+        ).to eq('3 minutes, 4 seconds')
+
+        expect(
+          (1000.years).to_rounded_s(:long)
+        ).to eq("1000 years")
+
+        expect(0.seconds.to_rounded_s).to eq("0 seconds")
+        expect(0.minutes.to_rounded_s).to eq("0 seconds")
+        expect(0.months.to_rounded_s).to eq("0 seconds")
+        expect(0.years.to_rounded_s).to eq("0 seconds")
+      end
+
+      describe 'normalizes the string by default' do
+        it 'for a single unit value' do
+          expect(30.days.to_rounded_s).to eq("1 month")
+        end
+
+        it "normalizes the string by default" do
+          input = (365 + 30 + 1).days
+          expect(input.to_rounded_s).to eq('1 year, 1 month')
+        end
+      end
+
+      it "converts units into a micro format" do
+        expect(
+          (1.hour 3.minutes 4.seconds).to_rounded_s(:micro)
+        ).to eq("1h")
+
+        expect(
+          (1.year 3.months 4.days).to_rounded_s(:micro)
+        ).to eq("1y")
+      end
+
+      it "converts units into a medium format" do
+        expect(
+          (1.hour 3.minutes 4.seconds).to_rounded_s(:short)
+        ).to eq("1hr 3min")
+
+        expect(
+          (1.year 3.months 4.days).to_rounded_s(:short)
+        ).to eq("1yr 3mo")
+      end
+
+      it "converts units using a user-defined format" do
+        expect(
+          (1.hour 3.minutes 4.seconds).to_rounded_s(
+            units: {
+              seconds: "second(s)",
+              minutes: "minute(s)",
+              hours: "hour(s)"
+            },
+            separator: ' ',
+            delimiter: ' / '
+          )
+        ).to eq("1 hour(s) / 3 minute(s)")
+      end
+
+      it "uses user-defined options to override default format options" do
+        expect(8.days.to_rounded_s(separator: "_")).to eq("1_week, 1_day")
+        v = "1_week 1_day"
+        expect(8.days.to_rounded_s(separator: "_", delimiter: " ")).to eq(v)
+        expect(8.days.to_rounded_s(:micro, count: :all)).to eq("1w 1d")
+      end
+    end # describe 'passes all (adjusted) #to_s specs including'
+
+    describe 'by default, rounds to two units when' do
+      describe 'more than two units specified that are' do
+        describe 'not subject to rounding and' do
+          it 'all adjacent' do
+            input = (2.hours 3.minutes 4.seconds)
+            expect(input.to_rounded_s).to eq('2 hours, 3 minutes')
+          end
+
+          it 'not adjacent' do
+            input = (1.month 3.hours 5.seconds)
+            expect(input.to_rounded_s).to eq('1 month, 3 hours')
+          end
+          end # describe 'not subject to rounding and'
+
+          describe 'subject to rounding due to' do
+            it 'the third unit being rounded up' do
+              input = (3.days 4.hours 31.minutes)
+              expect(input.to_rounded_s).to eq('3 days, 5 hours')
+            end
+          end # describe 'subject to rounding due to'
+      end # describe 'more than two units specified that are'
+    end # describe 'by default, rounds to two units when'
+  end # describe '#to_rounded_s'
+end


### PR DESCRIPTION
This PR supersedes PR #7, which was quite rightly shat upon. Sorry it took so long to get back to this; strokes/health problems and office-corporate gyrations are no fun at all. Especially in combination.

To address your review comments on #7:

- `lib/timerizer/duration/rounded.rb` (and matching spec) have been completely ripped out and replaced by `lib/timerizer/duration/rounded_time.rb`, which should address each and all of your comments about that file's code. (Rake in particular is no longer in the loop; I have used your existing `.gemspec` for this code);
- Your `.gitignore` has been restored, and the `bin/*` files (including the environment-specific setup) no longer exist;
- The funky `Time`-to-`Duration`-and-back specs are gone. Good riddance.
- The _only_ specs I've added now are the specs for `#to_rounded_s` itself, which are closely patterned on the `#to_s` specs.

Hopefully this will be acceptable.

I think `#to_rounded_s` delivers value over simply using `#to_s` with a `count` option because sometimes (as in our use cases), people care about the _closest_ time unit. For example, rounding `(1.year 6.months 27.days)` to "1 year, 7 months" when presented as part of "Article updated about 1 year, 7 months ago" than "At least 1 year, 6 months ago". Our use cases resolve around (possibly intermittently-published) content, and several of our user-facing displays have received more favourable reviews when presented that way. Hence, here we are.

----
----

Commit comment follows.

----

This method converts a Duration to a human-readable string using a rounded value.

By 'rounded', we mean that the resulting value is rounded up if the input includes a value of more than half of one of the least-significant unit to be returned. For example, `(17.hours 43.minutes 31.seconds)`, when rounded to two units (hours and minutes), would return "17 hours, 44 minutes". By contrast, `#to_s`, with a `:count` option of 2, would return a value of "17 hours, 43 minutes": truncating, rather than rounding.

Note that this method overloads the meaning of the `:count` option value as documented. If the passed-in option value is numeric, it will be honored, and rounding will take place to that number of units. If the value is either `:all` or the default `nil`, then _rounding_ will be done to two units, and the rounded value will be passed on to `#to_s` with the options specified (which will result in a maximum of two time units being output).

The passed-in options are passed to `#to_s` as specified; rounding the _value_ to be formatted does not affect its _formatting_.