### PR TITLE
Add omitted new source file to timerizer.gemspec

### DIFF
--- a/timerizer.gemspec
+++ b/timerizer.gemspec
@@ -8,13 +8,7 @@ Gem::Specification.new do |gem|
   gem.description = "A simple set of Rails-like time helpers"
   gem.authors = ["Kyle Lacy"]
   gem.email = ["kylelacy@me.com"]
-  gem.files = [
-    "lib/timerizer.rb",
-    "lib/timerizer/core.rb",
-    "lib/timerizer/duration.rb",
-    "lib/timerizer/wall_clock.rb",
-    "lib/timerizer/version.rb"
-  ]
+  gem.files = Dir.glob('lib/**/*.rb')
   gem.homepage = "http://github.com/kylewlacy/timerizer"
 
   gem.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
When Timerizer 0.3.1 was released, `lib/timerizer/duration.rb` [included the line](https://github.com/kylewlacy/timerizer/blob/v0.3.1/lib/timerizer/duration.rb#L847)

```ruby
require_relative './duration/rounded_time'
```

That file exists in the released Gem, but it is not named in the `.gemspec` file. This causes any fresh installation of the Gem to fail immediately, as requiring the Gem will (indirectly) attempt to `require` that file and, when it fails, the loading of the Gem (and, e.g., running any code or tests) will also fail.

The `.gemspec` file lists the [files to be included](https://github.com/kylewlacy/timerizer/blob/v0.3.1/timerizer.gemspec#L11-L17) in the built Gem as

```ruby
  gem.files = [
    "lib/timerizer.rb",
    "lib/timerizer/core.rb",
    "lib/timerizer/duration.rb",
    "lib/timerizer/wall_clock.rb",
    "lib/timerizer/version.rb"
  ]
```

By changing those lines to

```ruby
  gem.files = Dir.glob('lib/**/*.rb')
```

all source files, and _only_ source files (not docs or test files or whatever) are included in the built Gem.

For reference, when using Bundler 1.17.*x*'s `bundle gem` command to build a new Gem's skeleton, the equivalent code in the generated Gemspec looks like

```ruby
  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
  end
```

which includes all files other than tests; e.g., the README and other documentation.