### PR TITLE
Updates for Ruby 2.6

### DIFF
--- a/lib/timerizer.rb
+++ b/lib/timerizer.rb
@@ -98,6 +98,7 @@ class Time
     Timerizer::Duration.new(seconds: time_between.round)
   end
 
+  undef_method :to_date
   # Convert {Time} to {Date}.
   # @return [Date] {Time} as {Date}
   # @example
@@ -107,6 +108,7 @@ class Time
     Date.new(self.year, self.month, self.day)
   end
 
+  undef_method :to_time
   # Convert self to {Time}.
   # @see Date#to_time
   def to_time
@@ -142,6 +144,7 @@ class Date
     number_of_days.fetch(self.month - 1)
   end
 
+  undef_method :to_date
   # Return self as {Date}.
   # @see Time#to_date
   def to_date

--- a/lib/timerizer/duration.rb
+++ b/lib/timerizer/duration.rb
@@ -630,7 +630,6 @@ module Timerizer
       end
 
       separator = format[:separator] || ' '
-      delimiter = format[:delimiter] || ', '
       units.take(count).map do |unit, n|
         unit_label = format_units.fetch(unit)
 

--- a/timerizer.gemspec
+++ b/timerizer.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |gem|
   gem.files = Dir.glob('lib/**/*.rb')
   gem.homepage = "http://github.com/kylewlacy/timerizer"
 
-  gem.add_development_dependency "bundler", "~> 1.14"
-  gem.add_development_dependency "rake", "~> 10.0"
-  gem.add_development_dependency "rspec", "~> 3.0"
-  gem.add_development_dependency "yard", "~> 0.9.9"
+  gem.add_development_dependency "bundler", "~> 2.0"
+  gem.add_development_dependency "rake", "~> 12.3"
+  gem.add_development_dependency "rspec", "~> 3.8"
+  gem.add_development_dependency "yard", "~> 0.9.20"
 end


### PR DESCRIPTION
I recently found this gem useful, but got some warnings under Ruby 2.6.4.

This patch updates the development gems to current versions and fixes some warning about redefining methods and unused locals.